### PR TITLE
Optimize frame saving pipeline with fan-out, buffered writes, and bac…

### DIFF
--- a/rataGUI/interface/camera_widget.py
+++ b/rataGUI/interface/camera_widget.py
@@ -159,6 +159,16 @@ class CameraWidget(QtWidgets.QWidget, Ui_CameraWidget):
         # Close camera when camera stops streaming
         self.camera.closeCamera()
 
+    async def _put_to_queue(self, target_queue, item, drop_policy="block"):
+        """Put item to a queue, respecting the drop policy."""
+        if drop_policy == "drop_oldest" and target_queue.full():
+            try:
+                target_queue.get_nowait()
+                target_queue.task_done()
+            except asyncio.QueueEmpty:
+                pass
+        await target_queue.put(item)
+
     # Asynchronous execution loop for an arbitrary plugin
     async def plugin_process(self, plugin):
         loop = asyncio.get_running_loop()
@@ -195,25 +205,65 @@ class CameraWidget(QtWidgets.QWidget, Ui_CameraWidget):
             finally:
                 plugin.in_queue.task_done()
 
+    async def fan_out(self, source_queue, target_plugins):
+        """Read from one source queue and distribute to multiple independent plugin queues."""
+        while True:
+            item = await source_queue.get()
+            try:
+                for plugin in target_plugins:
+                    await self._put_to_queue(plugin.in_queue, item, plugin.drop_policy)
+            finally:
+                source_queue.task_done()
+
     async def process_plugin_pipeline(self):
         # Add process to continuously acquire frames from camera
         acquisition_task = asyncio.create_task(self.acquire_frames())
 
-        # Add all plugin processes (pipeline) to async event loop
+        # Split plugins into serial prefix and independent tail group.
+        # Independent plugins at the end of the list run in parallel via fan-out.
+        # Any non-independent plugin breaks the independent group.
+        serial_plugins = list(self.plugins)
+        independent_plugins = []
+
+        # Walk backwards to find the trailing run of independent plugins
+        while serial_plugins and serial_plugins[-1].independent:
+            independent_plugins.insert(0, serial_plugins.pop())
+
+        # Wire serial plugins in chain
         plugin_tasks = []
-        for cur_plugin, next_plugin in zip(self.plugins, self.plugins[1:]):
-            # Connect outputs and inputs of consecutive plugin pairs
+        for cur_plugin, next_plugin in zip(serial_plugins, serial_plugins[1:]):
             cur_plugin.out_queue = next_plugin.in_queue
             plugin_tasks.append(asyncio.create_task(self.plugin_process(cur_plugin)))
-        # Add terminating plugin
-        plugin_tasks.append(asyncio.create_task(self.plugin_process(self.plugins[-1])))
+
+        fan_out_queue = None
+        if independent_plugins:
+            fan_out_queue = asyncio.Queue()
+            if serial_plugins:
+                # Last serial plugin fans out to all independent plugins
+                serial_plugins[-1].out_queue = fan_out_queue
+                plugin_tasks.append(asyncio.create_task(self.plugin_process(serial_plugins[-1])))
+            else:
+                # All plugins are independent — acquisition feeds the fan-out queue directly.
+                # Swap in fan_out_queue as the first plugin's in_queue so acquire_frames() feeds it.
+                self.plugins[0].in_queue = fan_out_queue
+
+            plugin_tasks.append(asyncio.create_task(self.fan_out(fan_out_queue, independent_plugins)))
+
+            # Each independent plugin runs as a terminal plugin
+            for plugin in independent_plugins:
+                plugin_tasks.append(asyncio.create_task(self.plugin_process(plugin)))
+        else:
+            # No independent plugins — add terminating serial plugin
+            plugin_tasks.append(asyncio.create_task(self.plugin_process(serial_plugins[-1])))
 
         # Wait until camera stops running
         await acquisition_task
 
-        # Wait for plugins to finish processing
+        # Wait for all plugin queues to drain
         for plugin in self.plugins:
             await plugin.in_queue.join()
+        if fan_out_queue is not None:
+            await fan_out_queue.join()
 
         # Cancel idle plugin processes
         for task in plugin_tasks:

--- a/rataGUI/plugins/base_plugin.py
+++ b/rataGUI/plugins/base_plugin.py
@@ -33,6 +33,8 @@ class BasePlugin(ABC):
         )
         self.active = True
         self.blocking = False
+        self.independent = False  # Independent plugins can run in parallel via fan-out
+        self.drop_policy = "block"  # "block" or "drop_oldest" when in_queue is full
         self.config = config.as_dict()  # freeze plugin settings
         self.in_queue = Queue(queue_size)
         self.out_queue = None

--- a/rataGUI/plugins/frame_display.py
+++ b/rataGUI/plugins/frame_display.py
@@ -26,8 +26,10 @@ class FrameDisplay(BasePlugin):
         "Fixed Interval": 0,
     }
 
-    def __init__(self, cam_widget, config, queue_size=0):
+    def __init__(self, cam_widget, config, queue_size=3):
         super().__init__(cam_widget, config, queue_size)
+        self.independent = True
+        self.drop_policy = "drop_oldest"
 
         self.frame_width = config.get("Frame width")
         self.frame_height = config.get("Frame height")

--- a/rataGUI/plugins/video_writer.py
+++ b/rataGUI/plugins/video_writer.py
@@ -55,6 +55,8 @@ class VideoWriter(BasePlugin):
 
     def __init__(self, cam_widget, config, queue_size=0):
         super().__init__(cam_widget, config, queue_size)
+        self.blocking = True
+        self.independent = True
         self.input_params = {}
         self.output_params = {}
 
@@ -157,18 +159,25 @@ class VideoWriter(BasePlugin):
 
 
 import subprocess as sp
+import threading
+import queue
 from shutil import which
 
 
 class FFMPEG_Writer:
     """Write frames using ffmpeg as backend
 
+    Uses an internal bounded queue and dedicated writer thread to decouple
+    frame encoding from the caller, preventing blocking I/O from stalling
+    the plugin pipeline.
+
     :param filename: path to write video file to
     :param input_dict: dictionary of input parameters to interpret data from Python
     :param output_dict: dictionary of output parameters to encode data to disk
+    :param buffer_size: max frames to buffer before backpressure (default 120 ~4s at 30fps)
     """
 
-    def __init__(self, file_path, input_dict={}, output_dict={}, verbosity=0):
+    def __init__(self, file_path, input_dict={}, output_dict={}, verbosity=0, buffer_size=120):
 
         self.file_path = os.path.abspath(os.path.normpath(file_path))
         dir_path = os.path.dirname(self.file_path)
@@ -186,6 +195,25 @@ class FFMPEG_Writer:
 
         if self._FFMPEG_PATH is None:
             raise IOError("Could not find ffmpeg executable in the environment PATH.")
+
+        self._write_queue = queue.Queue(maxsize=buffer_size)
+        self._write_thread = None
+        self._write_error = None
+
+    def _write_loop(self):
+        """Dedicated thread that drains the write queue to FFMPEG stdin."""
+        try:
+            while True:
+                data = self._write_queue.get()
+                if data is None:  # Sentinel: shutdown
+                    break
+                try:
+                    self._proc.stdin.write(data)
+                except IOError as err:
+                    self._write_error = err
+                    break
+        except Exception as err:
+            self._write_error = err
 
     def start_process(self, H, W, C):
         self.initialized = True
@@ -222,7 +250,7 @@ class FFMPEG_Writer:
             out_args.append('-b:v')
             out_args.append('8M')
         """
-        
+
         cmd = [self._FFMPEG_PATH, "-y", "-f", "rawvideo"] + in_args + ["-i", "-", '-an'] + out_args + [self.file_path]
 
         self._cmd = " ".join(cmd)
@@ -239,6 +267,9 @@ class FFMPEG_Writer:
                 cmd, stdin=sp.PIPE, stdout=sp.DEVNULL, stderr=sp.STDOUT
             )
 
+        self._write_thread = threading.Thread(target=self._write_loop, daemon=True)
+        self._write_thread.start()
+
     def write_frame(self, img_array):
         """Writes one frame to the file."""
 
@@ -247,18 +278,21 @@ class FFMPEG_Writer:
         if not self.initialized:
             self.start_process(H, W, C)
 
-        # print(img_array.dtype)
-        img_array = img_array.astype(np.uint8)
-
-        try:
-            self._proc.stdin.write(img_array.tobytes())
-        except IOError as err:
-            # Show the command and stderr from pipe
-            msg = f"{str(err)}\n\n FFMPEG COMMAND:{self._cmd}\n"
+        if self._write_error is not None:
+            msg = f"{str(self._write_error)}\n\n FFMPEG COMMAND:{self._cmd}\n"
             raise IOError(msg)
 
+        img_array = img_array.astype(np.uint8)
+
+        # Enqueue frame bytes; blocks if buffer is full (backpressure)
+        self._write_queue.put(img_array.tobytes())
+
     def close(self):
-        """Closes the writer and terminates the subprocess if is still alive."""
+        """Closes the writer, flushing all buffered frames before terminating."""
+        if self._write_thread is not None and self._write_thread.is_alive():
+            self._write_queue.put(None)  # Sentinel to stop write loop
+            self._write_thread.join(timeout=30)
+
         if self._proc is None or self._proc.poll() is not None:
             return
 


### PR DESCRIPTION
…kpressure

VideoWriter was blocking the asyncio event loop with synchronous FFMPEG stdin writes, stalling all other plugins (including FrameDisplay). This commit:

- Sets VideoWriter.blocking=True so it runs in ThreadPoolExecutor
- Adds internal bounded write queue + dedicated thread in FFMPEG_Writer to decouple process() return time from FFMPEG I/O latency
- Introduces fan-out pipeline: independent plugins (VideoWriter, FrameDisplay) at the tail of the pipeline now receive frames in parallel instead of serially
- Adds drop_oldest policy for FrameDisplay's bounded queue (size 3) so display stays responsive even when other plugins are slow
- Adds independent and drop_policy attributes to BasePlugin (defaults preserve existing serial behavior for backward compatibility)

https://claude.ai/code/session_015xsm3L86fjJDiG1haxiSTe