### PR TITLE
Optimize camera recording and frame display for high-res/multi-cam sc…

### DIFF
--- a/rataGUI/interface/camera_widget.py
+++ b/rataGUI/interface/camera_widget.py
@@ -18,8 +18,9 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-# process_pool = ProcessPoolExecutor()
-thread_pool = ThreadPoolExecutor()
+# Shared bounded thread pool for camera I/O and blocking plugin execution.
+# Sized for up to 4 cameras with acquisition + blocking plugin threads each.
+thread_pool = ThreadPoolExecutor(max_workers=8)
 
 EXP_AVG_DECAY = 0.8
 
@@ -127,7 +128,7 @@ class CameraWidget(QtWidgets.QWidget, Ui_CameraWidget):
             while self.camera._running:
                 if self.active:
                     status, frame = await loop.run_in_executor(
-                        None, self.camera.readCamera
+                        thread_pool, self.camera.readCamera
                     )
                     metadata = self.camera.getMetadata()
                     metadata["Camera Name"] = self.camera.getDisplayName()
@@ -180,7 +181,7 @@ class CameraWidget(QtWidgets.QWidget, Ui_CameraWidget):
                 if plugin.active:
                     if plugin.blocking:  # possibly move queues outside plugins
                         result = await loop.run_in_executor(
-                            None, plugin.process, frame, metadata
+                            thread_pool, plugin.process, frame, metadata
                         )
                     else:
                         result = plugin.process(frame, metadata)

--- a/rataGUI/plugins/frame_display.py
+++ b/rataGUI/plugins/frame_display.py
@@ -3,6 +3,7 @@ from rataGUI.plugins.base_plugin import BasePlugin
 from PyQt6 import QtGui
 from PyQt6.QtCore import Qt, QObject, pyqtSignal
 
+import cv2
 import logging
 
 logger = logging.getLogger(__name__)
@@ -45,22 +46,24 @@ class FrameDisplay(BasePlugin):
         self.interval = max(0,self.interval-1)
         if self.interval == 0:
             img_h, img_w, num_ch = frame.shape
+            target_w, target_h = self.frame_width, self.frame_height
 
-            # Convert to pixmap and set to video frame
+            # Downscale with cv2 before creating QImage — faster than Qt scaling
+            # and produces a smaller QImage, reducing memory and QPixmap conversion cost
+            if img_w != target_w or img_h != target_h:
+                if self.config.get("Aspect ratio"):
+                    scale = min(target_w / img_w, target_h / img_h)
+                    new_w = int(img_w * scale)
+                    new_h = int(img_h * scale)
+                else:
+                    new_w, new_h = target_w, target_h
+                frame = cv2.resize(frame, (new_w, new_h), interpolation=cv2.INTER_LINEAR)
+                img_h, img_w, num_ch = frame.shape
+
             bytes_per_line = num_ch * img_w
             qt_image = QtGui.QImage(
                 frame.data, img_w, img_h, bytes_per_line, QtGui.QImage.Format.Format_RGB888
             )
-            if self.config.get("Aspect ratio"):
-                qt_image = qt_image.scaled(
-                    self.frame_width, self.frame_height, Qt.AspectRatioMode.KeepAspectRatio
-                )
-            else:
-                qt_image = qt_image.scaled(
-                    self.frame_width,
-                    self.frame_height,
-                    Qt.AspectRatioMode.IgnoreAspectRatio,
-                )
 
             self.signal.image.emit(qt_image)
             self.interval = self.config.get("Fixed Interval")

--- a/rataGUI/plugins/video_writer.py
+++ b/rataGUI/plugins/video_writer.py
@@ -45,6 +45,7 @@ class VideoWriter(BasePlugin):
             "gray",
         ],
         "Write Frame Index": True,
+        "Buffer Size (frames)": 120,
     }
 
     DISPLAY_CONFIG_MAP = {
@@ -77,6 +78,8 @@ class VideoWriter(BasePlugin):
                     self.save_dir = os.path.normpath(value)
             elif prop_name == "Write Frame Index":
                 self.write_frame_index = value
+            elif prop_name == "Buffer Size (frames)":
+                self.buffer_size = int(value)
             elif prop_name == "filename suffix":
                 self.file_name = slugify(cam_widget.camera.getDisplayName())
                 if len(value)>0:
@@ -139,6 +142,7 @@ class VideoWriter(BasePlugin):
             input_dict=self.input_params,
             output_dict=self.output_params,
             verbosity=0,
+            buffer_size=getattr(self, 'buffer_size', 120),
         )
 
     def process(self, frame, metadata):
@@ -208,7 +212,8 @@ class FFMPEG_Writer:
                 if data is None:  # Sentinel: shutdown
                     break
                 try:
-                    self._proc.stdin.write(data)
+                    # Write numpy buffer directly via memoryview — zero-copy to pipe
+                    self._proc.stdin.write(memoryview(data))
                 except IOError as err:
                     self._write_error = err
                     break
@@ -251,20 +256,23 @@ class FFMPEG_Writer:
             out_args.append('8M')
         """
 
-        cmd = [self._FFMPEG_PATH, "-y", "-f", "rawvideo"] + in_args + ["-i", "-", '-an'] + out_args + [self.file_path]
+        cmd = [self._FFMPEG_PATH, "-y", "-f", "rawvideo"] + in_args + ["-i", "-", '-an', '-threads', '0'] + out_args + [self.file_path]
 
         self._cmd = " ".join(cmd)
 
+        # Use 1MB pipe buffer to reduce write syscalls for large frames
+        pipe_bufsize = 1024 * 1024
+
         if self.verbosity >= 2:
             logger.info(cmd)
-            self._proc = sp.Popen(cmd, stdin=sp.PIPE, stdout=sp.PIPE, stderr=None)
+            self._proc = sp.Popen(cmd, stdin=sp.PIPE, stdout=sp.PIPE, stderr=None, bufsize=pipe_bufsize)
         elif self.verbosity == 1:
             cmd += ["-v", "warning"]
             logger.info(cmd)
-            self._proc = sp.Popen(cmd, stdin=sp.PIPE, stdout=sp.PIPE, stderr=None)
+            self._proc = sp.Popen(cmd, stdin=sp.PIPE, stdout=sp.PIPE, stderr=None, bufsize=pipe_bufsize)
         else:
             self._proc = sp.Popen(
-                cmd, stdin=sp.PIPE, stdout=sp.DEVNULL, stderr=sp.STDOUT
+                cmd, stdin=sp.PIPE, stdout=sp.DEVNULL, stderr=sp.STDOUT, bufsize=pipe_bufsize
             )
 
         self._write_thread = threading.Thread(target=self._write_loop, daemon=True)
@@ -282,10 +290,11 @@ class FFMPEG_Writer:
             msg = f"{str(self._write_error)}\n\n FFMPEG COMMAND:{self._cmd}\n"
             raise IOError(msg)
 
-        img_array = img_array.astype(np.uint8)
+        # Ensure uint8 C-contiguous layout; no-copy when already correct
+        img_array = np.ascontiguousarray(img_array, dtype=np.uint8)
 
-        # Enqueue frame bytes; blocks if buffer is full (backpressure)
-        self._write_queue.put(img_array.tobytes())
+        # Enqueue numpy array directly; byte serialization deferred to writer thread
+        self._write_queue.put(img_array)
 
     def close(self):
         """Closes the writer, flushing all buffered frames before terminating."""


### PR DESCRIPTION
…enarios

- Eliminate redundant frame copies in FFMPEG_Writer: use np.ascontiguousarray (no-copy when already uint8+contiguous) and enqueue numpy arrays directly instead of bytes, deferring serialization to the dedicated writer thread
- Write to ffmpeg stdin via memoryview for zero-copy pipe writes
- Enable multi-threaded ffmpeg encoding with -threads 0
- Increase subprocess pipe buffer to 1MB to reduce write syscalls
- Make writer buffer size configurable via "Buffer Size (frames)" setting
- Replace Qt QImage.scaled() with cv2.resize(INTER_LINEAR) in FrameDisplay for faster downscaling and smaller QImage/QPixmap allocations
- Fix ThreadPoolExecutor: bound to max_workers=8 and actually use it in run_in_executor calls instead of the default unbounded executor

https://claude.ai/code/session_015qAUUasMYhdnAQ5f1wPrwj