### PR TITLE
Add AV1 codec support (av1_nvenc, libsvtav1) and CUDA safety checks

### DIFF
--- a/rataGUI/plugins/video_writer.py
+++ b/rataGUI/plugins/video_writer.py
@@ -4,8 +4,10 @@ from rataGUI import launch_config
 from pathlib import Path
 
 import os
+import subprocess as _sp
 import numpy as np
 from datetime import datetime
+from shutil import which as _which
 
 import logging
 
@@ -14,6 +16,9 @@ logger = logging.getLogger(__name__)
 
 # Cached NVIDIA driver version (None = not yet checked, False = unavailable)
 _nvidia_driver_version_cache = None
+
+# NVENC codec names (single source of truth)
+_NVENC_CODECS = ('h264_nvenc', 'hevc_nvenc', 'av1_nvenc')
 
 
 def _get_nvidia_driver_version():
@@ -46,6 +51,76 @@ def _get_nvidia_driver_version():
     return None
 
 
+# Cached set of encoder names available in the ffmpeg binary
+_ffmpeg_encoder_cache = {}
+
+
+def _check_ffmpeg_encoder_available(encoder_name):
+    """Check if a specific encoder is compiled into the ffmpeg binary.
+
+    Runs ``ffmpeg -encoders`` once, caches the full set of encoder names,
+    and returns True/False for the requested encoder.
+    """
+    global _ffmpeg_encoder_cache
+    if _ffmpeg_encoder_cache:  # already populated
+        return encoder_name in _ffmpeg_encoder_cache
+
+    ffmpeg_path = _which("ffmpeg")
+    if ffmpeg_path is None:
+        return False
+
+    try:
+        result = _sp.run(
+            [ffmpeg_path, "-encoders"],
+            capture_output=True, text=True, timeout=10,
+        )
+        if result.returncode == 0:
+            for line in result.stdout.splitlines():
+                parts = line.strip().split()
+                # Format: "V..... libx264  ..." (6-char flags field, then name)
+                if len(parts) >= 2 and len(parts[0]) == 6:
+                    _ffmpeg_encoder_cache[parts[1]] = True
+    except Exception as err:
+        logger.debug(f"Could not query ffmpeg encoders: {err}")
+
+    return encoder_name in _ffmpeg_encoder_cache
+
+
+# Cached CUDA hwaccel availability (None = not checked, True/False = result)
+_ffmpeg_cuda_available_cache = None
+
+
+def _check_ffmpeg_cuda_available():
+    """Check if ffmpeg was compiled with CUDA hwaccel support.
+
+    Runs ``ffmpeg -hwaccels`` and checks for 'cuda' in the output.
+    Result is cached for the process lifetime.
+    """
+    global _ffmpeg_cuda_available_cache
+    if _ffmpeg_cuda_available_cache is not None:
+        return _ffmpeg_cuda_available_cache
+
+    ffmpeg_path = _which("ffmpeg")
+    if ffmpeg_path is None:
+        _ffmpeg_cuda_available_cache = False
+        return False
+
+    try:
+        result = _sp.run(
+            [ffmpeg_path, "-hwaccels"],
+            capture_output=True, text=True, timeout=10,
+        )
+        if result.returncode == 0:
+            hwaccels = result.stdout.lower().split()
+            _ffmpeg_cuda_available_cache = "cuda" in hwaccels
+            return _ffmpeg_cuda_available_cache
+    except Exception as err:
+        logger.debug(f"Could not query ffmpeg hwaccels: {err}")
+
+    _ffmpeg_cuda_available_cache = False
+    return False
+
+
 class VideoWriter(BasePlugin):
     """
     Plugin that writes frames to video file using FFMPEG
@@ -56,7 +131,7 @@ class VideoWriter(BasePlugin):
     DEFAULT_CONFIG = {
         "Save directory": "",  # Defaults to camera widget's save directory
         "filename suffix": "",
-        "vcodec": ["libx264", "libx265", "h264_nvenc", "hevc_nvenc", "rawvideo"],
+        "vcodec": ["libx264", "libx265", "h264_nvenc", "hevc_nvenc", "av1_nvenc", "libsvtav1", "rawvideo"],
         "framerate": 30,
         "speed (preset)": [
             "p1",            # fastest (NVENC SDK 10+)
@@ -178,10 +253,12 @@ class VideoWriter(BasePlugin):
         vcodec = self.output_params.get("-vcodec")
         if vcodec in ["rawvideo"]:
             extension = ".raw"
-        elif vcodec in ['h264_nvenc', 'hevc_nvenc']:
+        elif vcodec in _NVENC_CODECS:
             self._configure_nvenc(vcodec, config)
         elif vcodec in ['libx264', 'libx265']:
             self._validate_cpu_preset(vcodec)
+        elif vcodec == 'libsvtav1':
+            self._configure_svtav1(vcodec)
 
         try:
             if os.access(self.save_dir, os.W_OK):
@@ -207,14 +284,25 @@ class VideoWriter(BasePlugin):
             output_dict=self.output_params,
             verbosity=0,
             buffer_size=getattr(self, 'buffer_size', 120),
-            gpu_pixel_conversion=self.gpu_pixel_conversion and vcodec in ['h264_nvenc', 'hevc_nvenc'],
+            gpu_pixel_conversion=self.gpu_pixel_conversion and vcodec in _NVENC_CODECS,
             use_hwaccel=self._use_hwaccel,
         )
 
     def _configure_nvenc(self, vcodec, config):
         """Configure NVENC-specific ffmpeg parameters with driver version awareness."""
+        # --- Encoder availability check ---
+        if not _check_ffmpeg_encoder_available(vcodec):
+            logger.warning(f"{vcodec} encoder not found in ffmpeg build; encoding may fail")
+
         preset = self.output_params.get("-preset")
         driver_version = _get_nvidia_driver_version()
+
+        # av1_nvenc requires NVENC SDK 12+ (driver >= 520)
+        if vcodec == 'av1_nvenc' and driver_version is not None and driver_version < 520:
+            logger.warning(
+                f"av1_nvenc requires NVIDIA driver >= 520 (detected {driver_version}). "
+                "Encoding may fail."
+            )
 
         # --- Preset mapping based on driver version ---
         if driver_version is not None and driver_version >= 456:
@@ -288,7 +376,10 @@ class VideoWriter(BasePlugin):
 
         # --- B-Frames ---
         if self.b_frames > 0:
-            self.output_params["-bf"] = str(self.b_frames)
+            if vcodec == 'av1_nvenc':
+                logger.warning("av1_nvenc does not support B-frames; ignoring B-Frames setting")
+            else:
+                self.output_params["-bf"] = str(self.b_frames)
 
         # --- Pixel format validation for NVENC ---
         nvenc_pix_fmts = {'yuv420p', 'nv12', 'p010le', 'yuv444p', 'yuv444p16le'}
@@ -299,8 +390,15 @@ class VideoWriter(BasePlugin):
 
         # --- CUDA hardware acceleration ---
         if self.gpu_pixel_conversion:
-            self._use_hwaccel = True
-            logger.info("CUDA hardware acceleration enabled for %s", vcodec)
+            if _check_ffmpeg_cuda_available():
+                self._use_hwaccel = True
+                logger.info("CUDA hardware acceleration enabled for %s", vcodec)
+            else:
+                logger.warning(
+                    "GPU Pixel Conversion requested but ffmpeg was not compiled with CUDA support. "
+                    "Disabling hardware acceleration."
+                )
+                self.gpu_pixel_conversion = False
 
     def _validate_cpu_preset(self, vcodec):
         """Validate that an NVENC-only preset isn't used with a CPU codec."""
@@ -310,6 +408,36 @@ class VideoWriter(BasePlugin):
         if preset in nvenc_only_presets:
             logger.warning(f"'{preset}' is an NVENC preset and not supported for {vcodec}, defaulting to medium")
             self.output_params["-preset"] = 'medium'
+
+    def _configure_svtav1(self, vcodec):
+        """Configure libsvtav1-specific ffmpeg parameters.
+
+        Maps text-based presets to SVT-AV1 numeric presets (0=slowest, 13=fastest).
+        """
+        if not _check_ffmpeg_encoder_available('libsvtav1'):
+            logger.warning("libsvtav1 encoder not found in ffmpeg build; encoding may fail")
+
+        preset = self.output_params.get("-preset")
+        text_to_numeric = {
+            'ultrafast': '12', 'veryfast': '10', 'fast': '8',
+            'medium': '5', 'slow': '3', 'slower': '1', 'veryslow': '0',
+            # NVENC presets mapped to reasonable SVT-AV1 equivalents
+            'p1': '12', 'p2': '10', 'p3': '8', 'p4': '5',
+            'p5': '3', 'p6': '1', 'p7': '0',
+        }
+        if preset in text_to_numeric:
+            mapped = text_to_numeric[preset]
+            logger.info(f"Mapping preset '{preset}' to SVT-AV1 numeric preset {mapped}")
+            self.output_params["-preset"] = mapped
+        elif preset is not None:
+            try:
+                val = int(preset)
+                if not (0 <= val <= 13):
+                    logger.warning(f"SVT-AV1 preset {val} out of range (0-13), defaulting to 5")
+                    self.output_params["-preset"] = '5'
+            except ValueError:
+                logger.warning(f"Unknown preset '{preset}' for libsvtav1, defaulting to 5")
+                self.output_params["-preset"] = '5'
 
     def process(self, frame, metadata):
         self.writer.write_frame(frame)
@@ -418,7 +546,7 @@ class FFMPEG_Writer:
 
         # GPU-side pixel format conversion via hwupload_cuda filter
         vcodec = self.output_dict.get('-vcodec', '')
-        if self.gpu_pixel_conversion and vcodec in ['h264_nvenc', 'hevc_nvenc']:
+        if self.gpu_pixel_conversion and vcodec in _NVENC_CODECS:
             pix_fmt = self.output_dict.get('-pix_fmt', 'yuv420p')
             out_args = ['-vf', f'format={pix_fmt},hwupload_cuda'] + out_args
 

--- a/tests/test_video_writer.py
+++ b/tests/test_video_writer.py
@@ -1,7 +1,10 @@
 import pytest
 from unittest.mock import patch, MagicMock
 import rataGUI.plugins.video_writer as vw_module
-from rataGUI.plugins.video_writer import VideoWriter, FFMPEG_Writer, _get_nvidia_driver_version
+from rataGUI.plugins.video_writer import (
+    VideoWriter, FFMPEG_Writer, _get_nvidia_driver_version,
+    _check_ffmpeg_encoder_available, _check_ffmpeg_cuda_available,
+)
 
 
 class TestGetNvidiaDriverVersion:
@@ -85,6 +88,8 @@ class TestValidateCpuPreset:
 class TestConfigureNvenc:
     def setup_method(self):
         vw_module._nvidia_driver_version_cache = None
+        vw_module._ffmpeg_encoder_cache = {}
+        vw_module._ffmpeg_cuda_available_cache = None
 
     def _make_nvenc_writer(self, **overrides):
         """Helper to create a MagicMock VideoWriter with standard NVENC attributes."""
@@ -104,8 +109,9 @@ class TestConfigureNvenc:
             setattr(writer, k, v)
         return writer
 
+    @patch("rataGUI.plugins.video_writer._check_ffmpeg_encoder_available", return_value=True)
     @patch("rataGUI.plugins.video_writer._get_nvidia_driver_version")
-    def test_sdk10_legacy_preset_mapping(self, mock_driver):
+    def test_sdk10_legacy_preset_mapping(self, mock_driver, _mock_enc):
         mock_driver.return_value = 535
         writer = self._make_nvenc_writer(
             output_params={"-preset": "fast", "-crf": "32", "-pix_fmt": "yuv420p"}
@@ -114,8 +120,9 @@ class TestConfigureNvenc:
         VideoWriter._configure_nvenc(writer, "h264_nvenc", config)
         assert writer.output_params["-preset"] == "p1"
 
+    @patch("rataGUI.plugins.video_writer._check_ffmpeg_encoder_available", return_value=True)
     @patch("rataGUI.plugins.video_writer._get_nvidia_driver_version")
-    def test_legacy_driver_new_preset_mapping(self, mock_driver):
+    def test_legacy_driver_new_preset_mapping(self, mock_driver, _mock_enc):
         mock_driver.return_value = 400  # old driver
         writer = self._make_nvenc_writer(
             output_params={"-preset": "p4", "-crf": "32", "-pix_fmt": "yuv420p"}
@@ -124,8 +131,9 @@ class TestConfigureNvenc:
         VideoWriter._configure_nvenc(writer, "h264_nvenc", config)
         assert writer.output_params["-preset"] == "medium"
 
+    @patch("rataGUI.plugins.video_writer._check_ffmpeg_encoder_available", return_value=True)
     @patch("rataGUI.plugins.video_writer._get_nvidia_driver_version")
-    def test_rate_control_constqp(self, mock_driver):
+    def test_rate_control_constqp(self, mock_driver, _mock_enc):
         mock_driver.return_value = 535
         writer = self._make_nvenc_writer(
             output_params={"-preset": "p4", "-crf": "28", "-pix_fmt": "yuv420p"},
@@ -137,8 +145,9 @@ class TestConfigureNvenc:
         assert writer.output_params["-cq"] == "28"
         assert "-crf" not in writer.output_params
 
+    @patch("rataGUI.plugins.video_writer._check_ffmpeg_encoder_available", return_value=True)
     @patch("rataGUI.plugins.video_writer._get_nvidia_driver_version")
-    def test_rate_control_cbr_with_bitrate(self, mock_driver):
+    def test_rate_control_cbr_with_bitrate(self, mock_driver, _mock_enc):
         mock_driver.return_value = 535
         writer = self._make_nvenc_writer(rate_control="cbr", bitrate_mbps=10)
         config = MagicMock()
@@ -146,32 +155,36 @@ class TestConfigureNvenc:
         assert writer.output_params["-rc"] == "cbr"
         assert writer.output_params["-b:v"] == "10M"
 
+    @patch("rataGUI.plugins.video_writer._check_ffmpeg_encoder_available", return_value=True)
     @patch("rataGUI.plugins.video_writer._get_nvidia_driver_version")
-    def test_rate_control_cbr_zero_bitrate_defaults(self, mock_driver):
+    def test_rate_control_cbr_zero_bitrate_defaults(self, mock_driver, _mock_enc):
         mock_driver.return_value = 535
         writer = self._make_nvenc_writer(rate_control="cbr", bitrate_mbps=0)
         config = MagicMock()
         VideoWriter._configure_nvenc(writer, "h264_nvenc", config)
         assert writer.output_params["-b:v"] == "8M"
 
+    @patch("rataGUI.plugins.video_writer._check_ffmpeg_encoder_available", return_value=True)
     @patch("rataGUI.plugins.video_writer._get_nvidia_driver_version")
-    def test_gpu_index(self, mock_driver):
+    def test_gpu_index(self, mock_driver, _mock_enc):
         mock_driver.return_value = 535
         writer = self._make_nvenc_writer(gpu_index=2)
         config = MagicMock()
         VideoWriter._configure_nvenc(writer, "h264_nvenc", config)
         assert writer.output_params["-gpu"] == "2"
 
+    @patch("rataGUI.plugins.video_writer._check_ffmpeg_encoder_available", return_value=True)
     @patch("rataGUI.plugins.video_writer._get_nvidia_driver_version")
-    def test_b_frames(self, mock_driver):
+    def test_b_frames(self, mock_driver, _mock_enc):
         mock_driver.return_value = 535
         writer = self._make_nvenc_writer(b_frames=3)
         config = MagicMock()
         VideoWriter._configure_nvenc(writer, "h264_nvenc", config)
         assert writer.output_params["-bf"] == "3"
 
+    @patch("rataGUI.plugins.video_writer._check_ffmpeg_encoder_available", return_value=True)
     @patch("rataGUI.plugins.video_writer._get_nvidia_driver_version")
-    def test_unsupported_pix_fmt_defaults(self, mock_driver):
+    def test_unsupported_pix_fmt_defaults(self, mock_driver, _mock_enc):
         mock_driver.return_value = 535
         writer = self._make_nvenc_writer(
             output_params={"-preset": "p4", "-pix_fmt": "rgb24"}
@@ -180,13 +193,63 @@ class TestConfigureNvenc:
         VideoWriter._configure_nvenc(writer, "h264_nvenc", config)
         assert writer.output_params["-pix_fmt"] == "yuv420p"
 
+    @patch("rataGUI.plugins.video_writer._check_ffmpeg_encoder_available", return_value=True)
     @patch("rataGUI.plugins.video_writer._get_nvidia_driver_version")
-    def test_sdk10_tune_applied(self, mock_driver):
+    def test_sdk10_tune_applied(self, mock_driver, _mock_enc):
         mock_driver.return_value = 535
         writer = self._make_nvenc_writer(tune="hq")
         config = MagicMock()
         VideoWriter._configure_nvenc(writer, "h264_nvenc", config)
         assert writer.output_params["-tune"] == "hq"
+
+    # --- av1_nvenc-specific tests ---
+
+    @patch("rataGUI.plugins.video_writer._check_ffmpeg_encoder_available", return_value=True)
+    @patch("rataGUI.plugins.video_writer._get_nvidia_driver_version")
+    def test_av1_nvenc_b_frames_skipped(self, mock_driver, _mock_enc):
+        """av1_nvenc does not support B-frames; -bf should not appear."""
+        mock_driver.return_value = 535
+        writer = self._make_nvenc_writer(b_frames=3)
+        config = MagicMock()
+        VideoWriter._configure_nvenc(writer, "av1_nvenc", config)
+        assert "-bf" not in writer.output_params
+
+    @patch("rataGUI.plugins.video_writer._check_ffmpeg_encoder_available", return_value=True)
+    @patch("rataGUI.plugins.video_writer._get_nvidia_driver_version")
+    def test_av1_nvenc_low_driver_warns(self, mock_driver, _mock_enc):
+        """av1_nvenc should warn when driver < 520."""
+        mock_driver.return_value = 470
+        writer = self._make_nvenc_writer()
+        config = MagicMock()
+        with patch("rataGUI.plugins.video_writer.logger") as mock_logger:
+            VideoWriter._configure_nvenc(writer, "av1_nvenc", config)
+            warning_msgs = [str(c) for c in mock_logger.warning.call_args_list]
+            assert any("520" in w for w in warning_msgs)
+
+    # --- CUDA safety tests ---
+
+    @patch("rataGUI.plugins.video_writer._check_ffmpeg_cuda_available", return_value=False)
+    @patch("rataGUI.plugins.video_writer._check_ffmpeg_encoder_available", return_value=True)
+    @patch("rataGUI.plugins.video_writer._get_nvidia_driver_version")
+    def test_cuda_unavailable_disables_hwaccel(self, mock_driver, _mock_enc, _mock_cuda):
+        """When CUDA is not in ffmpeg, gpu_pixel_conversion should be disabled."""
+        mock_driver.return_value = 535
+        writer = self._make_nvenc_writer(gpu_pixel_conversion=True)
+        config = MagicMock()
+        VideoWriter._configure_nvenc(writer, "h264_nvenc", config)
+        assert writer._use_hwaccel is False
+        assert writer.gpu_pixel_conversion is False
+
+    @patch("rataGUI.plugins.video_writer._check_ffmpeg_cuda_available", return_value=True)
+    @patch("rataGUI.plugins.video_writer._check_ffmpeg_encoder_available", return_value=True)
+    @patch("rataGUI.plugins.video_writer._get_nvidia_driver_version")
+    def test_cuda_available_enables_hwaccel(self, mock_driver, _mock_enc, _mock_cuda):
+        """When CUDA is available, gpu_pixel_conversion should enable hwaccel."""
+        mock_driver.return_value = 535
+        writer = self._make_nvenc_writer(gpu_pixel_conversion=True)
+        config = MagicMock()
+        VideoWriter._configure_nvenc(writer, "h264_nvenc", config)
+        assert writer._use_hwaccel is True
 
 
 class TestFFMPEGWriter:
@@ -330,8 +393,10 @@ class TestHwaccelFlags:
             call_kwargs = mock_sp.Popen.call_args
             assert call_kwargs[1]["bufsize"] == 1024 * 1024
 
+    @patch("rataGUI.plugins.video_writer._check_ffmpeg_cuda_available", return_value=True)
+    @patch("rataGUI.plugins.video_writer._check_ffmpeg_encoder_available", return_value=True)
     @patch("rataGUI.plugins.video_writer._get_nvidia_driver_version")
-    def test_configure_nvenc_sets_hwaccel_flag(self, mock_driver):
+    def test_configure_nvenc_sets_hwaccel_flag(self, mock_driver, _mock_enc, _mock_cuda):
         """Verify _configure_nvenc sets _use_hwaccel when gpu_pixel_conversion is True."""
         mock_driver.return_value = 535
         writer = MagicMock()
@@ -349,8 +414,9 @@ class TestHwaccelFlags:
 
         assert writer._use_hwaccel is True
 
+    @patch("rataGUI.plugins.video_writer._check_ffmpeg_encoder_available", return_value=True)
     @patch("rataGUI.plugins.video_writer._get_nvidia_driver_version")
-    def test_configure_nvenc_no_hwaccel_without_gpu_conversion(self, mock_driver):
+    def test_configure_nvenc_no_hwaccel_without_gpu_conversion(self, mock_driver, _mock_enc):
         """Verify _configure_nvenc does NOT set _use_hwaccel when gpu_pixel_conversion is False."""
         mock_driver.return_value = 535
         writer = MagicMock()
@@ -367,3 +433,123 @@ class TestHwaccelFlags:
         VideoWriter._configure_nvenc(writer, "h264_nvenc", config)
 
         assert writer._use_hwaccel is False
+
+
+class TestCheckFfmpegEncoderAvailable:
+    def setup_method(self):
+        vw_module._ffmpeg_encoder_cache = {}
+
+    @patch("rataGUI.plugins.video_writer._which", return_value="/usr/bin/ffmpeg")
+    @patch("rataGUI.plugins.video_writer._sp")
+    def test_encoder_found(self, mock_sp, _mock_which):
+        mock_sp.run.return_value = MagicMock(
+            returncode=0,
+            stdout=(
+                "Encoders:\n"
+                " V..... libx264              libx264 H.264\n"
+                " V..... av1_nvenc            NVIDIA NVENC AV1\n"
+            ),
+        )
+        assert _check_ffmpeg_encoder_available("av1_nvenc") is True
+
+    @patch("rataGUI.plugins.video_writer._which", return_value="/usr/bin/ffmpeg")
+    @patch("rataGUI.plugins.video_writer._sp")
+    def test_encoder_not_found(self, mock_sp, _mock_which):
+        mock_sp.run.return_value = MagicMock(
+            returncode=0,
+            stdout=(
+                "Encoders:\n"
+                " V..... libx264              libx264 H.264\n"
+            ),
+        )
+        assert _check_ffmpeg_encoder_available("av1_nvenc") is False
+
+    @patch("rataGUI.plugins.video_writer._which", return_value="/usr/bin/ffmpeg")
+    @patch("rataGUI.plugins.video_writer._sp")
+    def test_caching(self, mock_sp, _mock_which):
+        mock_sp.run.return_value = MagicMock(
+            returncode=0,
+            stdout=" V..... libsvtav1            SVT-AV1\n",
+        )
+        _check_ffmpeg_encoder_available("libsvtav1")
+        _check_ffmpeg_encoder_available("libsvtav1")
+        assert mock_sp.run.call_count == 1
+
+    @patch("rataGUI.plugins.video_writer._which", return_value=None)
+    def test_no_ffmpeg(self, _mock_which):
+        assert _check_ffmpeg_encoder_available("libx264") is False
+
+
+class TestCheckFfmpegCudaAvailable:
+    def setup_method(self):
+        vw_module._ffmpeg_cuda_available_cache = None
+
+    @patch("rataGUI.plugins.video_writer._which", return_value="/usr/bin/ffmpeg")
+    @patch("rataGUI.plugins.video_writer._sp")
+    def test_cuda_available(self, mock_sp, _mock_which):
+        mock_sp.run.return_value = MagicMock(
+            returncode=0,
+            stdout="Hardware acceleration methods:\ncuda\nvdpau\n",
+        )
+        assert _check_ffmpeg_cuda_available() is True
+
+    @patch("rataGUI.plugins.video_writer._which", return_value="/usr/bin/ffmpeg")
+    @patch("rataGUI.plugins.video_writer._sp")
+    def test_cuda_not_available(self, mock_sp, _mock_which):
+        mock_sp.run.return_value = MagicMock(
+            returncode=0,
+            stdout="Hardware acceleration methods:\nvdpau\nvaapi\n",
+        )
+        assert _check_ffmpeg_cuda_available() is False
+
+    @patch("rataGUI.plugins.video_writer._which", return_value="/usr/bin/ffmpeg")
+    @patch("rataGUI.plugins.video_writer._sp")
+    def test_caching(self, mock_sp, _mock_which):
+        mock_sp.run.return_value = MagicMock(
+            returncode=0,
+            stdout="Hardware acceleration methods:\ncuda\n",
+        )
+        _check_ffmpeg_cuda_available()
+        _check_ffmpeg_cuda_available()
+        assert mock_sp.run.call_count == 1
+
+
+class TestConfigureSvtav1:
+    def setup_method(self):
+        vw_module._ffmpeg_encoder_cache = {}
+
+    @patch("rataGUI.plugins.video_writer._check_ffmpeg_encoder_available", return_value=True)
+    def test_text_preset_mapped(self, _mock_enc):
+        writer = MagicMock(spec=VideoWriter)
+        writer.output_params = {"-preset": "fast", "-crf": "30"}
+        VideoWriter._configure_svtav1(writer, "libsvtav1")
+        assert writer.output_params["-preset"] == "8"
+
+    @patch("rataGUI.plugins.video_writer._check_ffmpeg_encoder_available", return_value=True)
+    def test_nvenc_preset_mapped(self, _mock_enc):
+        writer = MagicMock(spec=VideoWriter)
+        writer.output_params = {"-preset": "p4", "-crf": "30"}
+        VideoWriter._configure_svtav1(writer, "libsvtav1")
+        assert writer.output_params["-preset"] == "5"
+
+    @patch("rataGUI.plugins.video_writer._check_ffmpeg_encoder_available", return_value=True)
+    def test_numeric_preset_preserved(self, _mock_enc):
+        writer = MagicMock(spec=VideoWriter)
+        writer.output_params = {"-preset": "8", "-crf": "30"}
+        VideoWriter._configure_svtav1(writer, "libsvtav1")
+        assert writer.output_params["-preset"] == "8"
+
+    @patch("rataGUI.plugins.video_writer._check_ffmpeg_encoder_available", return_value=True)
+    def test_out_of_range_numeric_defaults(self, _mock_enc):
+        writer = MagicMock(spec=VideoWriter)
+        writer.output_params = {"-preset": "20", "-crf": "30"}
+        VideoWriter._configure_svtav1(writer, "libsvtav1")
+        assert writer.output_params["-preset"] == "5"
+
+    @patch("rataGUI.plugins.video_writer._check_ffmpeg_encoder_available", return_value=False)
+    def test_encoder_unavailable_warns(self, _mock_enc):
+        writer = MagicMock(spec=VideoWriter)
+        writer.output_params = {"-preset": "medium"}
+        with patch("rataGUI.plugins.video_writer.logger") as mock_logger:
+            VideoWriter._configure_svtav1(writer, "libsvtav1")
+            mock_logger.warning.assert_called()


### PR DESCRIPTION
- Add av1_nvenc (GPU) and libsvtav1 (CPU) to supported video codecs
- Add _check_ffmpeg_encoder_available() to detect if encoders are compiled into the ffmpeg binary, warning when they're missing
- Add _check_ffmpeg_cuda_available() to detect CUDA hwaccel support, gracefully disabling GPU pixel conversion when unavailable
- Handle av1_nvenc-specific constraints: skip B-frames (unsupported), warn when NVIDIA driver < 520 (requires SDK 12+)
- Add _configure_svtav1() with preset mapping from text names to SVT-AV1 numeric presets (0-13)
- Extract _NVENC_CODECS tuple to avoid hardcoded codec lists
- Add 14 new tests covering all new functionality

https://claude.ai/code/session_01Jxw4BA7y1oumQDWWHtAHRH