### PR TITLE
Add development install instructions using pip install -e

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,10 +70,16 @@ Note: A "session" is a recording session. Every time you press start, it starts 
 
 # Development Guide
 
-RataGUI's modular framework was built for user customizability and integration. We encourage you to [fork](https://guides.github.com/activities/forking/#fork) the package [Github repository](https://github.com/BrainHu42/rataGUI) and add additional modules for your specific use case. Then, run the following command to clone the forked repository to your computer. 
+RataGUI's modular framework was built for user customizability and integration. We encourage you to [fork](https://guides.github.com/activities/forking/#fork) the package [Github repository](https://github.com/BrainHu42/rataGUI) and add additional modules for your specific use case. Then, clone the forked repository and install in editable mode:
 ```
 git clone https://github.com/<YOUR-USERNAME>/rataGUI.git
+cd rataGUI
+conda create -n rataGUI ffmpeg pip python=3.10
+conda activate rataGUI
+python -m pip install -e ".[test]"
 ```
+
+This installs rataGUI in editable mode so that any source changes take effect immediately without reinstalling.
 
 ## Implement Custom Camera Models
 To add another camera model, simply rename and edit the required functions provided in `cameras/TemplateCamera.py` to fit your camera model's specifications. RataGUI will use these functions to find, initialize, read frames from and close the camera. Any configurable camera settings should be specified in the dictionary named `DEFAULT_PROPS`. RataGUI will use these default settings to automatically create a dynamic menu and add it to the user interface. The configured settings will be passed into the `initializeCamera` function.
@@ -85,9 +91,8 @@ To incorporate additional functionality, simply rename and edit the required fun
 To interface with other external devices, simply rename and edit the required functions provided in `triggers/template_trigger.py` to fit your custom use case. RataGUI will use these functions to populate the trigger tab in the user interface with all available devices and their configurable settings. Trigger devices can be controlled through the interface as well as within a plugin process. 
 
 ## Running Tests
-RataGUI includes a comprehensive test suite. To run the tests:
+RataGUI includes a comprehensive test suite. If you used the development install above, pytest is already included. To run the tests:
 ```
-pip install pytest
 pytest
 ```
 

--- a/docs/install-guide.md
+++ b/docs/install-guide.md
@@ -23,12 +23,26 @@ python -m pip install rataGUI
 
 ## Pip Installation (CPU-only)
 
-If you don't want to download Anaconda or its lightweight variants (miniconda, miniforge etc.), you can install RataGUI as a standalone pip package in any python>=3.10 environment. However, creating a separate virtual environment is strongly suggested so that RataGUI doesn't conflict with other installed packages. 
+If you don't want to download Anaconda or its lightweight variants (miniconda, miniforge etc.), you can install RataGUI as a standalone pip package in any python>=3.10 environment. However, creating a separate virtual environment is strongly suggested so that RataGUI doesn't conflict with other installed packages.
 > Note: Unlike conda, pip can't automatically install ffmpeg for video encoding so it needs to be installed through the official download [links](https://ffmpeg.org/download.html) or using a package manager (e.g. `sudo apt install ffmpeg` on Debian/Ubuntu, `brew install ffmpeg` on macOS, etc.).
 
 ```
 python -m pip install rataGUI
 ```
+
+## Development Install (from source)
+
+To install from a cloned GitHub repository for development, use an editable install. This lets you modify the source code and see changes immediately without reinstalling.
+
+```
+git clone https://github.com/<YOUR-USERNAME>/rataGUI.git
+cd rataGUI
+conda create -n rataGUI ffmpeg pip python=3.10
+conda activate rataGUI
+python -m pip install -e ".[test]"
+```
+
+> Note: The `-e` flag installs in editable mode, so the package links to your local source tree instead of copying files into `site-packages`. The `[test]` extra installs pytest for running the test suite.
 
 ## External Hardware
 
@@ -52,8 +66,8 @@ python -m pip install nidaqmx
 ```
 
 ## Running Tests
-RataGUI includes a unit test suite that can be run without any hardware connected. Install the test dependencies and run:
+RataGUI includes a unit test suite that can be run without any hardware connected. If you used the development install above, pytest is already included. Otherwise, install it first:
 ```
-pip install pytest
+python -m pip install "rataGUI[test]"
 pytest
 ```


### PR DESCRIPTION
## Summary

- Added a "Development Install (from source)" section to `docs/install-guide.md` with full `git clone` + `conda create` + `pip install -e ".[test]"` workflow
- Updated README Development Guide to include the complete editable install steps after forking/cloning
- Updated "Running Tests" sections in both files to reference the `[test]` optional dependency instead of bare `pip install pytest`

## Verification

Tested the CPU-only install from the dev branch in a fresh conda environment:
- `conda create -n rataGUI ffmpeg pip python=3.10` — OK
- `pip install -e ".[test]"` from cloned repo — OK
- `import rataGUI` and `rataGUI --help` — OK
- `pytest` — **133/133 tests pass** (0.47s)

## Test plan

- [ ] Verify `pip install -e ".[test]"` works in a fresh conda env with Python 3.10
- [ ] Verify `pytest` passes after editable install
- [ ] Verify `rataGUI --help` entry point works

https://claude.ai/code/session_018nRcFUoeSwXDVDj3SHM1zt