### PR TITLE
Fix frame display freeze, latency spikes, and GPU encoding errors

### DIFF
--- a/rataGUI/interface/camera_widget.py
+++ b/rataGUI/interface/camera_widget.py
@@ -328,11 +328,19 @@ class CameraWidget(QtWidgets.QWidget, Ui_CameraWidget):
         if elapsed > 0:
             logger.debug("FPS: " + str(self.camera.frames_acquired / elapsed))
 
-    async def _put_to_queue(self, target_queue, item, drop_policy="block"):
-        """Put item to a queue, respecting the drop policy."""
+    async def _put_to_queue(self, target_queue, item, drop_policy="block", ring_buffer=None):
+        """Put item to a queue, respecting the drop policy.
+
+        When *ring_buffer* is provided and the dropped item is a slot index,
+        the slot is released so that the ring buffer does not leak.
+        """
         if drop_policy == "drop_oldest" and target_queue.full():
             try:
-                target_queue.get_nowait()
+                dropped = target_queue.get_nowait()
+                # Release the ring buffer slot for the dropped frame so
+                # that the producer can reuse it.
+                if ring_buffer is not None and isinstance(dropped, int):
+                    ring_buffer.release(dropped)
                 target_queue.task_done()
             except asyncio.QueueEmpty:
                 pass
@@ -350,6 +358,13 @@ class CameraWidget(QtWidgets.QWidget, Ui_CameraWidget):
             if ring_buffer is not None and isinstance(raw_item, int):
                 slot_idx = raw_item
                 frame, metadata = ring_buffer.get_view(slot_idx)
+                # For blocking plugins: copy the frame and release the slot
+                # immediately so the ring buffer is not held during the
+                # (potentially slow) thread-pool execution.
+                if plugin.blocking:
+                    frame = frame.copy()
+                    ring_buffer.release(slot_idx)
+                    slot_idx = None  # prevent double-release in finally
             else:
                 slot_idx = None
                 frame, metadata = raw_item
@@ -367,9 +382,12 @@ class CameraWidget(QtWidgets.QWidget, Ui_CameraWidget):
                     result = (frame, metadata)
 
                 # Send output to next plugin
-                if plugin.out_queue != None:
+                if plugin.out_queue is not None:
                     await plugin.out_queue.put(result)
-                else:
+                elif not plugin.blocking:
+                    # Only measure latency from non-blocking terminal plugins
+                    # (e.g. FrameDisplay) to avoid false spikes from slow
+                    # blocking plugins like VideoWriter.
                     delta_t = datetime.now() - metadata["Timestamp"]
                     self.avg_latency = (
                         delta_t.total_seconds() * 1000 * EXP_AVG_DECAY
@@ -393,15 +411,21 @@ class CameraWidget(QtWidgets.QWidget, Ui_CameraWidget):
         buffer and only the slot index (an int) is enqueued to each plugin,
         avoiding per-plugin copies of the full frame array.
         """
+        loop = asyncio.get_running_loop()
         while True:
             item = await source_queue.get()
             try:
                 if ring_buffer is not None:
                     frame, metadata = item
-                    slot_idx = ring_buffer.publish(frame, metadata)
+                    # Run publish in a thread to avoid blocking the event loop
+                    # when the ring buffer is full (backpressure).
+                    slot_idx = await loop.run_in_executor(
+                        None, ring_buffer.publish, frame, metadata
+                    )
                     for plugin in target_plugins:
                         await self._put_to_queue(
-                            plugin.in_queue, slot_idx, plugin.drop_policy
+                            plugin.in_queue, slot_idx, plugin.drop_policy,
+                            ring_buffer=ring_buffer,
                         )
                 else:
                     for plugin in target_plugins:

--- a/rataGUI/plugins/video_writer.py
+++ b/rataGUI/plugins/video_writer.py
@@ -459,6 +459,8 @@ class VideoWriter(BasePlugin):
 import subprocess as sp
 import threading
 import queue
+import time
+from collections import deque
 from shutil import which
 
 
@@ -501,6 +503,24 @@ class FFMPEG_Writer:
         self._write_queue = queue.Queue(maxsize=buffer_size)
         self._write_thread = None
         self._write_error = None
+        self._stderr_thread = None
+        self._stderr_lines = deque(maxlen=50)
+        self._proc = None
+
+    def _stderr_drain(self):
+        """Drain stderr into a bounded buffer to prevent pipe deadlock."""
+        try:
+            for line in self._proc.stderr:
+                text = line.decode('utf-8', errors='replace').rstrip()
+                self._stderr_lines.append(text)
+                if text:
+                    logger.debug("ffmpeg stderr: %s", text)
+        except Exception:
+            pass
+
+    def _get_stderr_output(self):
+        """Return captured stderr lines as a single string."""
+        return "\n".join(self._stderr_lines)
 
     def _write_loop(self):
         """Dedicated thread that drains the write queue to FFMPEG stdin."""
@@ -513,7 +533,13 @@ class FFMPEG_Writer:
                     # Write numpy buffer directly via memoryview — zero-copy to pipe
                     self._proc.stdin.write(memoryview(data))
                 except IOError as err:
-                    self._write_error = err
+                    stderr_msg = self._get_stderr_output()
+                    if stderr_msg:
+                        self._write_error = IOError(
+                            f"{err}\nFFMPEG stderr:\n{stderr_msg}"
+                        )
+                    else:
+                        self._write_error = err
                     break
         except Exception as err:
             self._write_error = err
@@ -566,18 +592,35 @@ class FFMPEG_Writer:
 
         if self.verbosity >= 2:
             logger.info(cmd)
-            self._proc = sp.Popen(cmd, stdin=sp.PIPE, stdout=sp.PIPE, stderr=None, bufsize=pipe_bufsize)
+            self._proc = sp.Popen(cmd, stdin=sp.PIPE, stdout=sp.PIPE, stderr=sp.PIPE, bufsize=pipe_bufsize)
         elif self.verbosity == 1:
             cmd += ["-v", "warning"]
             logger.info(cmd)
-            self._proc = sp.Popen(cmd, stdin=sp.PIPE, stdout=sp.PIPE, stderr=None, bufsize=pipe_bufsize)
+            self._proc = sp.Popen(cmd, stdin=sp.PIPE, stdout=sp.PIPE, stderr=sp.PIPE, bufsize=pipe_bufsize)
         else:
+            cmd += ["-v", "error"]
             self._proc = sp.Popen(
-                cmd, stdin=sp.PIPE, stdout=sp.DEVNULL, stderr=sp.STDOUT, bufsize=pipe_bufsize
+                cmd, stdin=sp.PIPE, stdout=sp.DEVNULL, stderr=sp.PIPE, bufsize=pipe_bufsize
             )
+
+        # Drain stderr in a background thread to prevent pipe buffer deadlock
+        self._stderr_thread = threading.Thread(target=self._stderr_drain, daemon=True)
+        self._stderr_thread.start()
 
         self._write_thread = threading.Thread(target=self._write_loop, daemon=True)
         self._write_thread.start()
+
+        # Brief check: if ffmpeg exits immediately (e.g. missing codec),
+        # raise now with the actual error instead of a cryptic broken pipe later.
+        time.sleep(0.05)
+        if self._proc.poll() is not None:
+            # Give stderr drain thread a moment to capture output
+            self._stderr_thread.join(timeout=1)
+            stderr_output = self._get_stderr_output()
+            raise IOError(
+                f"ffmpeg exited immediately (code {self._proc.returncode}): "
+                f"{stderr_output}\n\nFFMPEG COMMAND: {self._cmd}"
+            )
 
     def write_frame(self, img_array):
         """Writes one frame to the file."""
@@ -588,7 +631,10 @@ class FFMPEG_Writer:
             self.start_process(H, W, C)
 
         if self._write_error is not None:
+            stderr_output = self._get_stderr_output()
             msg = f"{str(self._write_error)}\n\n FFMPEG COMMAND:{self._cmd}\n"
+            if stderr_output:
+                msg += f"\nFFMPEG stderr:\n{stderr_output}\n"
             raise IOError(msg)
 
         # Ensure uint8 C-contiguous layout; no-copy when already correct
@@ -604,12 +650,16 @@ class FFMPEG_Writer:
             self._write_thread.join(timeout=30)
 
         if self._proc is None or self._proc.poll() is not None:
+            if self._stderr_thread is not None:
+                self._stderr_thread.join(timeout=5)
             return
 
         if self._proc.stdin:
             self._proc.stdin.close()
-        if self._proc.stderr:
-            self._proc.stderr.close()
 
         self._proc.wait()
+
+        if self._stderr_thread is not None:
+            self._stderr_thread.join(timeout=5)
+
         self._proc = None


### PR DESCRIPTION
Bug 1 - Frame display freezes when video_writer is active:
- Fix ring buffer slot leak: _put_to_queue now releases dropped slot indices back to the ring buffer, preventing permanent slot lockup
- Make ring_buffer.publish() non-blocking by running it in a thread executor, preventing asyncio event loop stalls during backpressure
- Release ring buffer slots early for blocking plugins by copying the frame before thread pool execution

Bug 2 - First camera latency measurement spikes:
- Only measure latency from non-blocking terminal plugins (FrameDisplay) to avoid false spikes from slow blocking plugins like VideoWriter

Bug 3 - GPU encoding (h264_nvenc) broken pipe with no diagnostics:
- Capture ffmpeg stderr at all verbosity levels via sp.PIPE
- Drain stderr in a background thread to prevent pipe buffer deadlock
- Add post-startup validation to detect immediate ffmpeg exit
- Include ffmpeg stderr output in error messages for broken pipes

https://claude.ai/code/session_01J9sFzUYwThoaqmWwyareG6