### PR TITLE
Fix NVIDIA encoder preset detection and frame display freeze

### DIFF
--- a/rataGUI/interface/camera_widget.py
+++ b/rataGUI/interface/camera_widget.py
@@ -410,6 +410,11 @@ class CameraWidget(QtWidgets.QWidget, Ui_CameraWidget):
         When *ring_buffer* is provided, frames are published into the ring
         buffer and only the slot index (an int) is enqueued to each plugin,
         avoiding per-plugin copies of the full frame array.
+
+        Blocking plugins receive a copied ``(frame, metadata)`` tuple and
+        their ring-buffer ref-count is released immediately so that slow
+        consumers cannot exhaust ring-buffer slots and stall non-blocking
+        plugins such as the frame display.
         """
         loop = asyncio.get_running_loop()
         while True:
@@ -423,10 +428,22 @@ class CameraWidget(QtWidgets.QWidget, Ui_CameraWidget):
                         None, ring_buffer.publish, frame, metadata
                     )
                     for plugin in target_plugins:
-                        await self._put_to_queue(
-                            plugin.in_queue, slot_idx, plugin.drop_policy,
-                            ring_buffer=ring_buffer,
-                        )
+                        if plugin.blocking:
+                            # Copy frame and release the slot immediately so
+                            # slow blocking plugins do not hold ring-buffer
+                            # slots and starve non-blocking consumers.
+                            view, meta = ring_buffer.get_view(slot_idx)
+                            frame_copy = view.copy()
+                            ring_buffer.release(slot_idx)
+                            await self._put_to_queue(
+                                plugin.in_queue, (frame_copy, meta),
+                                plugin.drop_policy,
+                            )
+                        else:
+                            await self._put_to_queue(
+                                plugin.in_queue, slot_idx, plugin.drop_policy,
+                                ring_buffer=ring_buffer,
+                            )
                 else:
                     for plugin in target_plugins:
                         await self._put_to_queue(

--- a/rataGUI/plugins/video_writer.py
+++ b/rataGUI/plugins/video_writer.py
@@ -121,6 +121,47 @@ def _check_ffmpeg_cuda_available():
     return False
 
 
+# Cached per-codec check for NVENC P-series preset support
+_ffmpeg_nvenc_new_presets_cache = {}
+
+
+def _check_nvenc_new_presets_available(encoder_name='h264_nvenc'):
+    """Check if the ffmpeg binary supports NVENC P-series presets (p1-p7).
+
+    Runs ``ffmpeg -h encoder=<encoder_name>`` and looks for P-series preset
+    names in the output.  Result is cached per encoder name.
+    """
+    if encoder_name in _ffmpeg_nvenc_new_presets_cache:
+        return _ffmpeg_nvenc_new_presets_cache[encoder_name]
+
+    ffmpeg_path = _which("ffmpeg")
+    if ffmpeg_path is None:
+        _ffmpeg_nvenc_new_presets_cache[encoder_name] = False
+        return False
+
+    try:
+        result = _sp.run(
+            [ffmpeg_path, "-h", f"encoder={encoder_name}"],
+            capture_output=True, text=True, timeout=10,
+        )
+        if result.returncode == 0:
+            import re
+            # Look for p1-p7 in the preset option description
+            has_new = bool(re.search(r'\bp[1-7]\b', result.stdout))
+            _ffmpeg_nvenc_new_presets_cache[encoder_name] = has_new
+            if not has_new:
+                logger.info(
+                    "ffmpeg %s does not advertise P-series presets; "
+                    "will use legacy preset names", encoder_name,
+                )
+            return has_new
+    except Exception as err:
+        logger.debug(f"Could not probe {encoder_name} presets: {err}")
+
+    _ffmpeg_nvenc_new_presets_cache[encoder_name] = False
+    return False
+
+
 class VideoWriter(BasePlugin):
     """
     Plugin that writes frames to video file using FFMPEG
@@ -304,8 +345,9 @@ class VideoWriter(BasePlugin):
                 "Encoding may fail."
             )
 
-        # --- Preset mapping based on driver version ---
-        if driver_version is not None and driver_version >= 456:
+        # --- Preset mapping based on driver version AND ffmpeg build ---
+        if (driver_version is not None and driver_version >= 456
+                and _check_nvenc_new_presets_available(vcodec)):
             # SDK 10+: prefer P1-P7 presets
             legacy_to_new = {
                 'fast': 'p1', 'medium': 'p4', 'slow': 'p7',


### PR DESCRIPTION
1. NVENC preset: The preset decision (p1-p7 vs legacy fast/medium/slow) now probes the actual ffmpeg binary via `ffmpeg -h encoder=<codec>` instead of relying solely on the NVIDIA driver version. This prevents using p-series presets when ffmpeg was compiled against an older NVENC SDK.

2. Ring buffer starvation: fan_out() now copies the frame and releases the ring-buffer slot immediately for blocking plugins (e.g. VideoWriter). Previously, slot indices accumulated in the blocking plugin's unbounded queue, exhausting all ring-buffer slots and causing publish() to block, which starved the frame display of new frames.

https://claude.ai/code/session_01JMezFf3KFJC4XM6S2DWG7j