### PR TITLE
Fix FLIR camera crash on restart and add diagnostic logging

### DIFF
--- a/rataGUI/cameras/FLIRCamera.py
+++ b/rataGUI/cameras/FLIRCamera.py
@@ -129,8 +129,25 @@ class FLIRCamera(BaseCamera):
             cam_list = FLIRCamera.getCameraList()
             self._stream = cam_list.GetBySerial(self.serial_num)
 
-            if not self._stream.IsInitialized():
-                self._stream.Init()
+            # Force a clean camera state regardless of previous session.
+            # If the previous process crashed, the camera may still be
+            # streaming or initialized, which makes property nodes read-only.
+            if self._stream.IsStreaming():
+                logger.warning(
+                    "Camera %s was still streaming (stale session?), stopping acquisition",
+                    self.serial_num,
+                )
+                self._stream.EndAcquisition()
+
+            if self._stream.IsInitialized():
+                logger.warning(
+                    "Camera %s was already initialized, reinitializing for clean state",
+                    self.serial_num,
+                )
+                self._stream.DeInit()
+
+            self._stream.Init()
+            logger.info("Camera %s initialized successfully", self.serial_num)
         except PySpin.SpinnakerException as err:
             logger.exception(err)
             logger.error("PySpin failed to find and initialize camera")
@@ -225,8 +242,21 @@ class FLIRCamera(BaseCamera):
                             node.SetValue(value)
             # Ensure RGB pixel format
             # self._stream.PixelFormat.SetValue(PySpin.PixelFormat_RGB8Packed)
-            self._stream.PixelFormat.SetValue(PySpin.PixelFormat_BayerRG8)
-            self._stream.IspEnable.SetValue(False)
+            if self._stream.PixelFormat.GetAccessMode() == PySpin.RW:
+                self._stream.PixelFormat.SetValue(PySpin.PixelFormat_BayerRG8)
+            else:
+                logger.warning(
+                    "PixelFormat node is not writable for camera %s (access mode: %s)",
+                    self.serial_num, self._stream.PixelFormat.GetAccessMode(),
+                )
+
+            if self._stream.IspEnable.GetAccessMode() == PySpin.RW:
+                self._stream.IspEnable.SetValue(False)
+            else:
+                logger.warning(
+                    "IspEnable node is not writable for camera %s (access mode: %s)",
+                    self.serial_num, self._stream.IspEnable.GetAccessMode(),
+                )
 
         except PySpin.SpinnakerException as err:
             logger.exception(err)
@@ -237,8 +267,10 @@ class FLIRCamera(BaseCamera):
         # print(self._stream.TLStream.StreamBufferHandlingMode.ToString())
         # print(self._stream.AcquisitionMode.ToString())
 
+        logger.info("Camera %s beginning acquisition", self.serial_num)
         self._stream.BeginAcquisition()
         self._running = True
+        logger.info("Camera %s acquisition started", self.serial_num)
 
         return True
 
@@ -298,7 +330,7 @@ class FLIRCamera(BaseCamera):
                     self._stream.EndAcquisition()
 
                 self._stream.DeInit()
-                del self._stream
+                self._stream = None
 
             self._running = False
             return True

--- a/rataGUI/interface/camera_widget.py
+++ b/rataGUI/interface/camera_widget.py
@@ -394,9 +394,26 @@ class CameraWidget(QtWidgets.QWidget, Ui_CameraWidget):
                         + self.avg_latency * (1 - EXP_AVG_DECAY)
                     )
             except Exception as err:
-                logger.exception(err)
                 failures += 1
+                logger.error(
+                    "Plugin %s failure #%d: camera=%s, frame_index=%s, "
+                    "frame_shape=%s, error=%s",
+                    type(plugin).__name__,
+                    failures,
+                    self.camera.getDisplayName(),
+                    metadata.get('Frame Index', '?') if metadata else '?',
+                    frame.shape if frame is not None else None,
+                    err,
+                )
+                logger.exception(err)
                 if failures > 5:  # close plugin after 5 failures
+                    logger.error(
+                        "Plugin %s exceeded failure threshold (5), deactivating. "
+                        "Camera: %s, total_frames_acquired: %d",
+                        type(plugin).__name__,
+                        self.camera.getDisplayName(),
+                        self.camera.frames_acquired,
+                    )
                     plugin.active = False
                     plugin.close()
             finally:

--- a/rataGUI/plugins/frame_display.py
+++ b/rataGUI/plugins/frame_display.py
@@ -42,31 +42,37 @@ class FrameDisplay(BasePlugin):
 
     def process(self, frame, metadata):
         """Sets pixmap image to video frame"""
-        # Get image dimensions
-        self.interval = max(0,self.interval-1)
-        if self.interval == 0:
-            img_h, img_w, num_ch = frame.shape
-            target_w, target_h = self.frame_width, self.frame_height
-
-            # Downscale with cv2 before creating QImage — faster than Qt scaling
-            # and produces a smaller QImage, reducing memory and QPixmap conversion cost
-            if img_w != target_w or img_h != target_h:
-                if self.config.get("Aspect ratio"):
-                    scale = min(target_w / img_w, target_h / img_h)
-                    new_w = int(img_w * scale)
-                    new_h = int(img_h * scale)
-                else:
-                    new_w, new_h = target_w, target_h
-                frame = cv2.resize(frame, (new_w, new_h), interpolation=cv2.INTER_LINEAR)
+        try:
+            self.interval = max(0, self.interval - 1)
+            if self.interval == 0:
                 img_h, img_w, num_ch = frame.shape
+                target_w, target_h = self.frame_width, self.frame_height
 
-            bytes_per_line = num_ch * img_w
-            qt_image = QtGui.QImage(
-                frame.data, img_w, img_h, bytes_per_line, QtGui.QImage.Format.Format_RGB888
+                # Downscale with cv2 before creating QImage — faster than Qt scaling
+                # and produces a smaller QImage, reducing memory and QPixmap conversion cost
+                if img_w != target_w or img_h != target_h:
+                    if self.config.get("Aspect ratio"):
+                        scale = min(target_w / img_w, target_h / img_h)
+                        new_w = int(img_w * scale)
+                        new_h = int(img_h * scale)
+                    else:
+                        new_w, new_h = target_w, target_h
+                    frame = cv2.resize(frame, (new_w, new_h), interpolation=cv2.INTER_LINEAR)
+                    img_h, img_w, num_ch = frame.shape
+
+                bytes_per_line = num_ch * img_w
+                qt_image = QtGui.QImage(
+                    frame.data, img_w, img_h, bytes_per_line, QtGui.QImage.Format.Format_RGB888
+                )
+
+                self.signal.image.emit(qt_image)
+                self.interval = self.config.get("Fixed Interval")
+        except Exception as err:
+            logger.error(
+                "FrameDisplay.process failed: frame_shape=%s, error=%s",
+                frame.shape if frame is not None else None, err,
             )
-
-            self.signal.image.emit(qt_image)
-            self.interval = self.config.get("Fixed Interval")
+            raise
 
         return frame, metadata
 

--- a/rataGUI/plugins/video_writer.py
+++ b/rataGUI/plugins/video_writer.py
@@ -482,11 +482,27 @@ class VideoWriter(BasePlugin):
                 self.output_params["-preset"] = '5'
 
     def process(self, frame, metadata):
-        self.writer.write_frame(frame)
+        try:
+            self.writer.write_frame(frame)
+        except Exception as err:
+            logger.error(
+                "VideoWriter.write_frame failed: frame_index=%s, frame_shape=%s, error=%s",
+                metadata.get('Frame Index', '?'), frame.shape, err,
+            )
+            raise
+
         if self.write_frame_index:
-            fi = metadata['Frame Index'] - 1
-            self.frameindex_file.write(fi.to_bytes(4, byteorder="little"))
-            self.timestamps_file.write(str(metadata["Timestamp"].timestamp()) + '\n')
+            try:
+                fi = metadata['Frame Index'] - 1
+                self.frameindex_file.write(fi.to_bytes(4, byteorder="little"))
+                self.timestamps_file.write(str(metadata["Timestamp"].timestamp()) + '\n')
+            except Exception as err:
+                logger.error(
+                    "VideoWriter failed writing frame index/timestamp: frame_index=%s, error=%s",
+                    metadata.get('Frame Index', '?'), err,
+                )
+                raise
+
         return frame, metadata
 
     def close(self):
@@ -548,6 +564,7 @@ class FFMPEG_Writer:
         self._stderr_thread = None
         self._stderr_lines = deque(maxlen=50)
         self._proc = None
+        self._frame_count = 0
 
     def _stderr_drain(self):
         """Drain stderr into a bounded buffer to prevent pipe deadlock."""
@@ -670,7 +687,12 @@ class FFMPEG_Writer:
         H, W, C = img_array.shape
 
         if not self.initialized:
+            logger.info(
+                "FFMPEG_Writer starting: frame_shape=(%d,%d,%d), file=%s",
+                H, W, C, self.file_path,
+            )
             self.start_process(H, W, C)
+            self._frame_count = 0
 
         if self._write_error is not None:
             stderr_output = self._get_stderr_output()
@@ -684,6 +706,16 @@ class FFMPEG_Writer:
 
         # Enqueue numpy array directly; byte serialization deferred to writer thread
         self._write_queue.put(img_array)
+
+        self._frame_count += 1
+        if self._frame_count % 1000 == 0:
+            qsize = self._write_queue.qsize()
+            proc_alive = self._proc.poll() is None if self._proc else False
+            logger.debug(
+                "FFMPEG_Writer health: frames_written=%d, queue_depth=%d, "
+                "proc_alive=%s, file=%s",
+                self._frame_count, qsize, proc_alive, self.file_path,
+            )
 
     def close(self):
         """Closes the writer, flushing all buffered frames before terminating."""


### PR DESCRIPTION
When a previous session crashes while cameras are streaming, the FLIR cameras remain in an acquired state. On next launch, initializeCamera() skipped re-initialization, causing PixelFormat.SetValue() to fail with "Node is not writable" since GenICam nodes are read-only during acquisition.

Fix: Always force a clean camera state by stopping acquisition and deinitializing before re-initializing. Add access mode checks on PixelFormat and IspEnable nodes. Fix closeCamera() to set _stream=None instead of del to prevent AttributeError on double-close.

Also add diagnostic logging throughout the plugin pipeline:
- Error context (frame index, shape) in VideoWriter and FrameDisplay
- FFMPEG process health checks every 1000 frames
- Camera state transition logging
- Enhanced failure context in plugin_process()

https://claude.ai/code/session_01JgyvnVHgCcvLs8DhNn9GNd