### PR TITLE
Add visible warnings for plugin failures

### DIFF
--- a/rataGUI/headless/runner.py
+++ b/rataGUI/headless/runner.py
@@ -515,7 +515,15 @@ class PipelineRunner:
                         ctx.camera.getDisplayName(),
                         ctx.camera.frames_acquired,
                     )
+                    plugin.failed = True
                     plugin.active = False
+                    logger.warning(
+                        "Plugin %s has been deactivated due to repeated failures. "
+                        "If this is VideoWriter, video is NOT being saved! "
+                        "Camera: %s",
+                        type(plugin).__name__,
+                        ctx.camera.getDisplayName(),
+                    )
                     plugin.close()
             finally:
                 if ring_buffer is not None and slot_idx is not None:

--- a/rataGUI/interface/camera_widget.py
+++ b/rataGUI/interface/camera_widget.py
@@ -42,6 +42,9 @@ class CameraWidget(QtWidgets.QWidget, Ui_CameraWidget):
     # Signal for when camera and plugins have been initialized
     pipeline_initialized = pyqtSignal()
 
+    # Signal emitted when a plugin is deactivated due to repeated errors
+    plugin_failed = pyqtSignal(str, str)  # (camera_name, plugin_name)
+
     def __init__(
         self, camera=None, cam_config=None, plugins=[], triggers=[], session_dir=""
     ):
@@ -420,7 +423,12 @@ class CameraWidget(QtWidgets.QWidget, Ui_CameraWidget):
                         self.camera.getDisplayName(),
                         self.camera.frames_acquired,
                     )
+                    plugin.failed = True
                     plugin.active = False
+                    self.plugin_failed.emit(
+                        self.camera.getDisplayName(),
+                        type(plugin).__name__,
+                    )
                     plugin.close()
             finally:
                 if ring_buffer is not None and slot_idx is not None:

--- a/rataGUI/interface/main_window.py
+++ b/rataGUI/interface/main_window.py
@@ -40,10 +40,12 @@ class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
         if dark_mode:
             self.active_color = QtGui.QColorConstants.DarkMagenta
             self.paused_color = QtGui.QColorConstants.DarkGray
+            self.failed_color = QtGui.QColorConstants.DarkRed
             self.inactive_color = QtGui.QColorConstants.Black
         else:
             self.active_color = QtGui.QColorConstants.Green
             self.paused_color = QtGui.QColorConstants.LightGray
+            self.failed_color = QtGui.QColorConstants.Red
             self.inactive_color = QtGui.QColorConstants.DarkGray
 
         # Create mappings from camID to camera, widget, config and model
@@ -113,8 +115,50 @@ class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
                 latency_str = str(round(cam_widget.avg_latency, 3)) + " ms"
                 self.cam_stats.item(row, 4).setText(latency_str)
 
-    # def update_plugin_stats(self):
-    #     pass
+        self.update_plugin_pipeline()
+
+    def update_plugin_pipeline(self):
+        """Refresh plugin pipeline table to reflect runtime state changes."""
+        for row, camID in enumerate(self.camera_names.keys()):
+            widget = self.camera_widgets.get(camID)
+            if widget is None:
+                continue
+            for col in range(self.plugin_pipeline.columnCount()):
+                header = self.plugin_pipeline.horizontalHeaderItem(col)
+                if header is None:
+                    continue
+                plugin_name = header.text()
+                if plugin_name not in self.plugins:
+                    continue
+
+                item = self.plugin_pipeline.item(row, col)
+                if item is None:
+                    continue
+
+                plugin_active = None
+                plugin_failed = False
+                for plugin in widget.plugins:
+                    if isinstance(plugin, self.plugins[plugin_name]):
+                        plugin_active = plugin.active
+                        plugin_failed = getattr(plugin, 'failed', False)
+                        break
+
+                if plugin_active is None:
+                    continue
+
+                current_text = item.text()
+                if plugin_failed and current_text != "Failed":
+                    self.plugin_pipeline.blockSignals(True)
+                    item.setText("Failed")
+                    item.setBackground(self.failed_color)
+                    item.setFlags(item.flags() & ~Qt.ItemFlag.ItemIsUserCheckable)
+                    self.plugin_pipeline.blockSignals(False)
+                elif not plugin_active and not plugin_failed and current_text == "Active":
+                    self.plugin_pipeline.blockSignals(True)
+                    item.setText("Paused")
+                    item.setCheckState(Qt.CheckState.Unchecked)
+                    item.setBackground(self.paused_color)
+                    self.plugin_pipeline.blockSignals(False)
 
     def populate_camera_stats(self):
         self.cam_stats.setRowCount(len(self.cameras))
@@ -324,9 +368,11 @@ class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
 
                 if widget is not None:  # Active
                     plugin_active = None
+                    plugin_failed = False
                     for plugin in widget.plugins:  # Find plugin by name
                         if isinstance(plugin, self.plugins[plugin_name]):
                             plugin_active = plugin.active
+                            plugin_failed = getattr(plugin, 'failed', False)
                             break
 
                     if not widget.active:
@@ -340,6 +386,9 @@ class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
                         item.setFlags(item.flags() | Qt.ItemFlag.ItemIsUserCheckable)
                         item.setCheckState(Qt.CheckState.Checked)
                         item.setBackground(self.active_color)
+                    elif plugin_failed:
+                        item.setText("Failed")
+                        item.setBackground(self.failed_color)
                     else:
                         item.setText("Paused")
                         item.setFlags(item.flags() | Qt.ItemFlag.ItemIsUserCheckable)
@@ -407,8 +456,16 @@ class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
                 item.setText("Disabled")
                 item.setBackground(self.inactive_color)
 
-    # def sync_trigger_checkbox(self, item):
-    #     pass
+    def _on_plugin_failed(self, camera_name, plugin_name):
+        """Show a warning dialog when a plugin is deactivated due to errors."""
+        QtWidgets.QMessageBox.warning(
+            self,
+            "Plugin Failed",
+            f"Plugin '{plugin_name}' has been deactivated due to repeated errors "
+            f"on camera '{camera_name}'.\n\n"
+            f"If this is VideoWriter, video is NOT being saved.\n"
+            f"Check the log for details.",
+        )
 
     def populate_trigger_list(self):
         def sync_check_box(item):
@@ -590,6 +647,8 @@ class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
                 widget.pipeline_initialized.connect(
                     lambda item=cam_item: item.setBackground(self.active_color)
                 )
+
+                widget.plugin_failed.connect(self._on_plugin_failed)
 
                 widget.destroyed.connect(
                     lambda _, id=camID, item=cam_item: reset_interface(id, item)

--- a/rataGUI/plugins/base_plugin.py
+++ b/rataGUI/plugins/base_plugin.py
@@ -32,6 +32,7 @@ class BasePlugin(ABC):
             f"Started {type(self).__name__} for: {cam_widget.camera.getDisplayName()}"
         )
         self.active = True
+        self.failed = False
         self.blocking = False
         self.independent = False  # Independent plugins can run in parallel via fan-out
         self.drop_policy = "block"  # "block" or "drop_oldest" when in_queue is full

--- a/tests/test_base_plugin.py
+++ b/tests/test_base_plugin.py
@@ -20,6 +20,7 @@ def plugin(mock_cam_widget, mock_config_manager):
 class TestBasePluginInit:
     def test_defaults(self, plugin):
         assert plugin.active is True
+        assert plugin.failed is False
         assert plugin.blocking is False
         assert plugin.independent is False
         assert plugin.drop_policy == "block"

--- a/tests/test_pipeline_runner.py
+++ b/tests/test_pipeline_runner.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+import logging
 import os
 from unittest.mock import MagicMock, patch
 
@@ -218,3 +219,62 @@ class TestPipelineRunnerLifecycle:
             BaseCamera.modules.pop("FanOutCam", None)
             BasePlugin.modules.pop("PluginA", None)
             BasePlugin.modules.pop("PluginB", None)
+
+
+class TestPluginFailureDeactivation:
+
+    @pytest.mark.asyncio
+    async def test_plugin_marked_failed_after_threshold(self, tmp_path):
+        """A plugin that always raises is marked failed=True after exceeding failure threshold."""
+        MockCamera = _make_camera_cls(num_cameras=1, num_frames=10)
+
+        from rataGUI.plugins.base_plugin import BasePlugin
+
+        class FailingPlugin(BasePlugin):
+            def __init__(self, cam_widget, config, queue_size=0):
+                super().__init__(cam_widget, config, queue_size)
+
+            def process(self, frame, metadata):
+                raise RuntimeError("simulated failure")
+
+        FailingPlugin.__name__ = "FailingPlugin"
+        FailingPlugin.__qualname__ = "FailingPlugin"
+
+        from rataGUI.cameras.BaseCamera import BaseCamera
+
+        BaseCamera.modules["FailCam"] = MockCamera
+        BasePlugin.modules["FailingPlugin"] = FailingPlugin
+
+        try:
+            config = {
+                "Enabled Camera Modules": ["FailCam"],
+                "Enabled Plugin Modules": ["FailingPlugin"],
+                "Enabled Trigger Modules": [],
+                "Save Directory": str(tmp_path),
+            }
+            runner = PipelineRunner(config)
+
+            # Capture warning logs directly (rataGUI logger has propagate=False)
+            runner_logger = logging.getLogger("rataGUI.headless.runner")
+            captured_warnings = []
+            handler = logging.Handler()
+            handler.setLevel(logging.WARNING)
+            handler.emit = lambda record: captured_warnings.append(record.getMessage())
+            runner_logger.addHandler(handler)
+
+            try:
+                await runner.run()
+            finally:
+                runner_logger.removeHandler(handler)
+
+            # Find the plugin instance from the runner's contexts
+            ctx = runner._contexts[0]
+            plugin = ctx.plugins[0]
+            assert plugin.failed is True
+            assert plugin.active is False
+
+            # Verify warning log was emitted
+            assert any("deactivated due to repeated failures" in m for m in captured_warnings)
+        finally:
+            BaseCamera.modules.pop("FailCam", None)
+            BasePlugin.modules.pop("FailingPlugin", None)


### PR DESCRIPTION
## Summary
- Add `failed` attribute to `BasePlugin` to distinguish crash-deactivation from user-initiated pause
- Show "Failed" state with red background in the plugin pipeline table (instead of ambiguous "Paused"), updated via the existing 250ms timer
- Display a `QMessageBox.warning()` dialog immediately when a plugin is deactivated due to repeated errors, via a new `plugin_failed` signal on `CameraWidget`
- Emit a WARNING-level log in headless mode explicitly stating video may not be saving

Fixes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)